### PR TITLE
Fixing zero-indexed arrays

### DIFF
--- a/UBJSON.php
+++ b/UBJSON.php
@@ -362,8 +362,6 @@ class UBJSON {
 			if ($tokenOpen == self::OBJECT_OPEN) {
 				$key = $this->_tokenValue;
 				$tokenCurrent = $this->_getNextToken();
-			} else {
-				++$key;
 			}
 
 			$value = $this->_decodeValue();
@@ -377,6 +375,10 @@ class UBJSON {
 			
 			if (in_array($tokenCurrent, $structEnd)) {
 				break;
+			}
+
+			if ($tokenOpen != self::OBJECT_OPEN) {
+				++$key;
 			}
 		}
 		

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
     "name": "dizews/php-ubjson",
     "require": {
         "php": ">=5.3.0"
+    },
+    "autoload": {
+        "classmap": ["vendor/dizews/php-ubjson/"]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
         "php": ">=5.3.0"
     },
     "autoload": {
-        "classmap": ["vendor/dizews/php-ubjson/"]
+        "classmap": ["./"]
     }
 }


### PR DESCRIPTION
In the original code the `$key` starts from `0` but is incremented inside the loop before being used.

Because of this an originally zero-indexed array would have (incorrectly) always started from an index of `1`.

This patch fixes the problem.
